### PR TITLE
fix: is() supports object

### DIFF
--- a/answers/ch04.ts
+++ b/answers/ch04.ts
@@ -75,12 +75,9 @@ is(10, 'foo') // エラー TS2345: 型 '"foo"' の引数を型 'number' の
               // パラメーターに割り当てることはできません。
 
 // ［難問］任意の数の引数を渡せるようにします
-is([1], [1], [1]) // true
-is([1], [1, 2], [1, 2, 3]) // false
+is(1, 1, 1) // true
+is(1, 2, 3) // false
 
 function is<T>(a: T, ...b: [T, ...T[]]): boolean {
-  if (typeof a === 'object') {
-    return b.every(_ => JSON.stringify(_) === JSON.stringify(a))
-  }
   return b.every(_ => _ === a)
 }

--- a/answers/ch04.ts
+++ b/answers/ch04.ts
@@ -75,8 +75,12 @@ is(10, 'foo') // エラー TS2345: 型 '"foo"' の引数を型 'number' の
               // パラメーターに割り当てることはできません。
 
 // ［難問］任意の数の引数を渡せるようにします
+is([1], [1], [1]) // true
 is([1], [1, 2], [1, 2, 3]) // false
 
 function is<T>(a: T, ...b: [T, ...T[]]): boolean {
+  if (typeof a === 'object') {
+    return b.every(_ => JSON.stringify(_) === JSON.stringify(a))
+  }
   return b.every(_ => _ === a)
 }


### PR DESCRIPTION
`is()` cannot return true even if they are the same when assigns object type.